### PR TITLE
Implemented proper AUTH=PLAIN mechanism

### DIFF
--- a/examples/imap_example.vsh
+++ b/examples/imap_example.vsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S v -n -w -cg -gc none  -cc tcc -d use_openssl -enable-globals run
 
-import freeflowuniverse.herolib.servers.mail.server
+import freeflowuniverse.uhurulib.lib.mail.server
 
 // Start the IMAP server on port 143
 server.start_demo()!

--- a/lib/mail/imap/README.md
+++ b/lib/mail/imap/README.md
@@ -15,8 +15,8 @@ A simple IMAP server implementation in V that supports basic mailbox operations.
 The server can be started with a simple function call:
 
 ```v
-import freeflowuniverse.herolib.servers.mail.imap
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.imap
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 
 fn main() {
     // Create the mail server

--- a/lib/mail/imap/cmd_authenticate.v
+++ b/lib/mail/imap/cmd_authenticate.v
@@ -3,36 +3,81 @@ module imap
 import net
 import io
 import freeflowuniverse.herolib.ui.console
+import encoding.base64
 
 // handle_authenticate processes the AUTHENTICATE command
-pub fn (mut self Session) handle_authenticate(tag string, parts []string) ! {
-	if parts.len < 3 {
+pub fn (mut self Session) handle_authenticate(tag string, cmd_parts []string) ! {
+	if cmd_parts.len < 3 {
 		self.conn.write('${tag} BAD AUTHENTICATE requires an authentication mechanism\r\n'.bytes())!
 		return
 	}
-	auth_type := parts[2].to_upper()
+	auth_type := cmd_parts[2].to_upper()
 	if auth_type == 'PLAIN' {
-		// Send continuation request for credentials
-		self.conn.write('+ \r\n'.bytes())!
-		// Read base64 credentials
-		creds := self.reader.read_line() or {
-			match err.msg() {
-				'closed' {
-					console.print_debug('Client disconnected during authentication')
-					return error('client disconnected during auth')
-				}
-				'EOF' {
-					console.print_debug('Client ended connection during authentication (EOF)')
-					return error('connection ended during auth')
-				}
-				else {
-					eprintln('Connection read error during authentication: ${err}')
-					return error('connection error during auth: ${err}')
+		mut creds := if cmd_parts.len > 3 {
+			cmd_parts[3]
+		} else {
+			// Send continuation request for credentials
+			self.conn.write('+\r\n'.bytes())!
+			// Read base64 credentials
+			self.reader.read_line() or {
+				match err.msg() {
+					'closed' {
+						console.print_debug('Client disconnected during authentication')
+						return error('client disconnected during auth')
+					}
+					'EOF' {
+						console.print_debug('Client ended connection during authentication (EOF)')
+						return error('connection ended during auth')
+					}
+					else {
+						eprintln('Connection read error during authentication: ${err}')
+						return error('connection error during auth: ${err}')
+					}
 				}
 			}
 		}
 		if creds.len > 0 {
-			// For demo purposes, accept any credentials
+			// Decode base64 credentials
+			decoded := base64.decode_str(creds)
+			if decoded.len == 0 {
+				self.conn.write('${tag} NO Invalid base64 encoding\r\n'.bytes())!
+				return
+			}
+
+			// AUTH=PLAIN format: [authzid]\0authcid\0password
+			// authzid is optional and can be empty
+			auth_parts := decoded.split('\0')
+			if auth_parts.len < 3 {
+				self.conn.write('${tag} NO Invalid AUTH=PLAIN format\r\n'.bytes())!
+				return
+			}
+
+			// Extract authentication identity (username) and password
+			// authzid := auth_parts[0] // Authorization identity (ignored for now)
+			authcid := auth_parts[1] // Authentication identity (username)
+			password := auth_parts[2] // Password
+
+			// Try to find existing account by email
+			email := '${authcid}@example.com'
+			existing_username := self.server.mailboxserver.account_find_by_email(email) or {
+				self.conn.write('${tag} NO [AUTHENTICATIONFAILED] Account not found\r\n'.bytes())!
+				return
+			}
+
+			// Authenticate the user
+			auth_success := self.server.mailboxserver.authenticate(existing_username, password) or {
+				self.conn.write('${tag} NO [AUTHENTICATIONFAILED] Authentication failed\r\n'.bytes())!
+				return
+			}
+
+			if !auth_success {
+				self.conn.write('${tag} NO [AUTHENTICATIONFAILED] Invalid credentials\r\n'.bytes())!
+				return
+			}
+
+			// Set the username in the session
+			self.username = existing_username
+
 			// After successful auth, remove STARTTLS and LOGINDISABLED capabilities
 			self.capabilities = ['IMAP4rev2', 'AUTH=PLAIN']
 			self.conn.write('${tag} OK [CAPABILITY IMAP4rev2 AUTH=PLAIN] Authentication successful\r\n'.bytes())!

--- a/lib/mail/imap/factory.v
+++ b/lib/mail/imap/factory.v
@@ -1,7 +1,7 @@
 module imap
 
 import time
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 
 pub fn new(mailboxserver &mailbox.MailServer) !IMAPServer {
 	mut server := IMAPServer{

--- a/lib/mail/imap/model.v
+++ b/lib/mail/imap/model.v
@@ -2,7 +2,7 @@ module imap
 
 import net
 import io
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 
 // IMAPServer wraps the mailbox server to provide IMAP functionality
 @[heap]

--- a/lib/mail/imap/server.v
+++ b/lib/mail/imap/server.v
@@ -96,6 +96,8 @@ fn handle_connection(mut conn net.TcpConn, mut server IMAPServer) ! {
 			continue
 		}
 		tag := parts[0]
+		// UID is an interesting command, in that it is a modifier to other commands (namely COPY, FETCH, STORE and SEARCH). It instructs the server to use UIDs as arguments or results, rather than message sequence numbers (as is the default)
+		// so cmd can be in index 1 or 2
 		cmd := parts[1].to_upper()
 		match cmd {
 			'LOGIN' {

--- a/lib/mail/mailbox/demodata.v
+++ b/lib/mail/mailbox/demodata.v
@@ -14,7 +14,7 @@ pub fn (mut self MailServer) demodata() ! {
 		emails := [primary_email, alt_email]
 
 		// Create user account (INBOX is created by default)
-		self.account_create(username, names[i], emails)!
+		self.account_create(username, names[i], emails, username)! // Use username as password for demo
 
 		// Create second mailbox
 		self.mailbox_create(username, 'Sent')!

--- a/lib/mail/mailbox/useraccount.v
+++ b/lib/mail/mailbox/useraccount.v
@@ -2,14 +2,27 @@ module mailbox
 
 import time
 
+import crypto.bcrypt
+
 // Represents a user account in the mail server
 @[heap]
 struct UserAccount {
 mut:
-	name        string
-	description string
-	emails      []string
-	mailboxes   map[string]&Mailbox // Map of mailbox name to mailbox instance
+	name          string
+	description   string
+	emails        []string
+	password_hash string    // Hashed password for authentication
+	mailboxes     map[string]&Mailbox // Map of mailbox name to mailbox instance
+}
+
+// Verifies user credentials
+fn (self UserAccount) authenticate(password string) bool {
+	// Verify password against stored hash
+	bcrypt.compare_hash_and_password(password.bytes(), self.password_hash.bytes()) or {
+		return false
+	}
+	
+	return true
 }
 
 // Creates a new mailbox for the user account

--- a/lib/mail/server/factory.v
+++ b/lib/mail/server/factory.v
@@ -1,8 +1,8 @@
 module server
 
-import freeflowuniverse.herolib.servers.mail.mailbox
-import freeflowuniverse.herolib.servers.mail.imap
-import freeflowuniverse.herolib.servers.mail.smtp
+import freeflowuniverse.uhurulib.lib.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.imap
+import freeflowuniverse.uhurulib.lib.mail.smtp
 
 pub fn start_demo() ! {
 	// Create the server and initialize an example INBOX.
@@ -18,6 +18,6 @@ pub fn start_demo() ! {
 
 	println('servers started.')
 
-	for {
+	for { 
 	}
 }

--- a/lib/mail/server/readme.md
+++ b/lib/mail/server/readme.md
@@ -5,7 +5,7 @@ see examples/servers/imap_example.vsh for example
 ```v
 #!/usr/bin/env -S v -n -w -cg -gc none  -cc tcc -d use_openssl -enable-globals run
 
-import freeflowuniverse.herolib.servers.mail.server
+import freeflowuniverse.uhurulib.lib.mail.server
 
 // Start the IMAP server on port 143
 server.start_demo() !

--- a/lib/mail/smtp/README.md
+++ b/lib/mail/smtp/README.md
@@ -16,8 +16,8 @@ A simple SMTP server implementation in V that integrates with the mailbox module
 The server can be started with a simple function call:
 
 ```v
-import freeflowuniverse.herolib.servers.mail.smtp
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.smtp
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 
 fn main() {
     // Create the mail server

--- a/lib/mail/smtp/factory.v
+++ b/lib/mail/smtp/factory.v
@@ -1,6 +1,6 @@
 module smtp
 
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 
 pub fn new(mailboxserver &mailbox.MailServer) !SMTPServer {
 	mut server := SMTPServer{

--- a/lib/mail/smtp/model.v
+++ b/lib/mail/smtp/model.v
@@ -2,7 +2,7 @@ module smtp
 
 import net
 import io
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 
 // SMTPServer wraps the mailbox server to provide SMTP functionality
 @[heap]

--- a/lib/mail/smtp/server.v
+++ b/lib/mail/smtp/server.v
@@ -3,7 +3,7 @@ module smtp
 import net
 import io
 import freeflowuniverse.herolib.ui.console
-import freeflowuniverse.herolib.servers.mail.mailbox
+import freeflowuniverse.uhurulib.lib.mail.mailbox
 import time
 
 // start starts the SMTP server on port 25 and accepts client connections


### PR DESCRIPTION
This PR implemented proper user account authentication for the IMAP server

It also fixes import errors caused by code being moved to a different repository.
**Main Changes:**

1. Changes to User Account Model
    - Added password field to UserAccount struct
    - Implemented authentication method to verify credentials
    - Updated account creation to include password parameter
2. Changes to Authentication Command
    - Implemented proper AUTH=PLAIN mechanism according to RFC
    - Added base64 decoding for credentials
    - Added proper credential validation
3. Changes to Tests and Demo Data
    - Updated test files to include password parameters
    - Modified demo data to use username as password for testing
    